### PR TITLE
Fix: Correct Werkzeug version to resolve Docker build error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ Flask-Login==0.6.3
 Flask-APScheduler
 psycopg2-binary
 bcrypt==4.0.1
-Werkzeug==2.0.4
+Werkzeug==2.0.3
 python-dotenv
 requests==2.31.0
 gunicorn==21.2.0


### PR DESCRIPTION
This commit corrects the `Werkzeug` library version to 2.0.3 to resolve a Docker build error.

The previous version of `Werkzeug` was invalid, which was causing the Docker build to fail. This commit corrects the version to a valid one.