### PR TITLE
Fix: Correct invalid URL endpoint in DOT templates

### DIFF
--- a/app/templates/dot/apply_permit.html
+++ b/app/templates/dot/apply_permit.html
@@ -7,7 +7,7 @@
     <!-- Breadcrumbs navigation -->
     <nav aria-label="breadcrumb" class="mb-4">
         <ol class="breadcrumb">
-            <li class="breadcrumb-item"><a href="{{ url_for('dot.index') }}">DOT Services</a></li>
+            <li class="breadcrumb-item"><a href="{{ url_for('dot.dashboard') }}">DOT Services</a></li>
             <li class="breadcrumb-item active" aria-current="page">Apply for Permit</li>
         </ol>
     </nav>

--- a/app/templates/dot/contest_ticket.html
+++ b/app/templates/dot/contest_ticket.html
@@ -6,7 +6,7 @@
     <!-- Breadcrumbs -->
     <nav aria-label="breadcrumb" class="mb-4">
         <ol class="breadcrumb">
-            <li class="breadcrumb-item"><a href="{{ url_for('dot.index') }}">DOT Services</a></li>
+            <li class="breadcrumb-item"><a href="{{ url_for('dot.dashboard') }}">DOT Services</a></li>
             <li class="breadcrumb-item"><a href="{{ url_for('dot.ticket_list') }}">Tickets</a></li>
             <li class="breadcrumb-item active" aria-current="page">Contest Ticket #{{ ticket.id }}</li>
         </ol>


### PR DESCRIPTION
This commit resolves a `werkzeug.routing.exceptions.BuildError` that occurred when rendering templates in the DOT module. The error was caused by an incorrect endpoint name being used in the `url_for` function.

The endpoint `dot.index` was being used, but the correct endpoint for the DOT dashboard is `dot.dashboard`.

This commit corrects the `url_for` call in the following files:
- `app/templates/dot/apply_permit.html`
- `app/templates/dot/contest_ticket.html`