### PR TITLE
Fix: Remove unnecessary joinedload in manage_accounts

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -59,8 +59,7 @@ def manage_accounts():
         query = query.join(User).filter(User.username.ilike(f'%{search_query}%'))
 
     accounts = query.options(
-        db.joinedload(Account.user),
-        db.joinedload(Account.farmer)
+        db.joinedload(Account.user)
     ).order_by(Account.id.desc()).paginate(page=page, per_page=per_page)
     
     return render_template('admin/manage_accounts.html', accounts=accounts, title="Manage Accounts")


### PR DESCRIPTION
This commit removes an unnecessary `db.joinedload(Account.farmer)` from the `manage_accounts` function in the admin routes. This was causing an `AttributeError` because the `Account` model does not have a direct relationship with the `Farmer` model.

The template for this view (`manage_accounts.html`) does not use the `farmer` attribute, so the eager load was not needed and could be safely removed.