### PR TITLE
Fix: Correct EditUserForm instantiation in edit_user route

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -228,11 +228,11 @@ def delete_user(user_id):
 @admin_required
 def edit_user(user_id):
     user = User.query.get_or_404(user_id)
-    form = EditUserForm(obj=user)
+    form = EditUserForm(original_username=user.username, original_email=user.email, obj=user)
     if form.validate_on_submit():
         user.username = form.username.data
         user.email = form.email.data
-        user.role_id = form.role_id.data
+        user.role = form.role.data
         db.session.commit()
         flash('User updated successfully.', 'success')
         return redirect(url_for('admin.manage_users'))


### PR DESCRIPTION
This commit fixes a `TypeError` that occurred when editing a user. The `EditUserForm` was being instantiated without the required `original_username` and `original_email` arguments.

The `edit_user` function in `app/routes/admin.py` has been updated to pass the user's current username and email when creating the form instance. This resolves the `TypeError` and allows the form to be used as intended.

Additionally, the code to update the user's role has been corrected from `user.role_id = form.role_id.data` to `user.role = form.role.data`.