### PR TITLE
Fix: Correctly build URL in edit_account.html template

### DIFF
--- a/app/templates/admin/edit_account.html
+++ b/app/templates/admin/edit_account.html
@@ -4,8 +4,8 @@
 {% block title %}Edit Account{% endblock %}
 
 {% block content %}
-<h1 class="mb-4">Edit Account</h1>
-<form method="POST" action="{{ url_for('admin.edit_account', account_id=account.id) }}">
+<h1 class="mb-4">{{ title }}</h1>
+<form method="POST" action="{{ url_for('admin.create_account') if not account.id else url_for('admin.edit_account', account_id=account.id) }}">
     {{ form.hidden_tag() }}
 
     {{ wtf.render_field(form.balance) }}


### PR DESCRIPTION
This commit fixes a `werkzeug.routing.exceptions.BuildError` that occurred when rendering the `admin/edit_account.html` template from the `create_account` route. The error was caused by the template trying to build a URL for the `edit_account` endpoint without an `account_id`.

The `edit_account.html` template has been updated to conditionally set the form's `action` attribute. If the `account` object has an `id`, it will use the `edit_account` endpoint; otherwise, it will use the `create_account` endpoint. This resolves the `BuildError` and allows the template to be rendered correctly for both creating and editing accounts.