### PR TITLE
Fix: Add cascade delete to Company model

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -368,7 +368,7 @@ class Company(db.Model):
     name = db.Column(db.String(128), nullable=False)
     details = db.Column(db.Text, nullable=True)
     user_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False)
-    user = db.relationship('User', backref=db.backref('company', uselist=False))
+    user = db.relationship('User', backref=db.backref('company', uselist=False, cascade="all, delete-orphan"))
 
     def __repr__(self):
         return f'<Company {self.name}>'


### PR DESCRIPTION
This commit fixes an `sqlalchemy.exc.IntegrityError` that occurred when deleting a user who owns a company. The error was caused by the `user_id` in the `companies` table not being allowed to be `NULL`.

The `Company` model has been updated to include `cascade="all, delete-orphan"` on the `user` relationship. This ensures that when a `User` is deleted, their associated `Company` is also deleted, preventing the `IntegrityError`.