### PR TITLE
Fix: Prevent GET requests to delete_user route

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -211,9 +211,13 @@ def tickets():
     # TODO: Fetch and display tickets from the database
     return render_template('admin/tickets.html')
 
-@admin_bp.route('/user/<int:user_id>/delete', methods=['POST'])
+@admin_bp.route('/user/<int:user_id>/delete', methods=['GET', 'POST'])
 @admin_required
 def delete_user(user_id):
+    if request.method == 'GET':
+        flash("To delete a user, please use the delete button on the Manage Users page.", "info")
+        return redirect(url_for('admin.manage_users'))
+
     form = DeleteUserForm(prefix=str(user_id))
     if form.validate_on_submit():
         user_to_delete = User.query.get_or_404(user_id)


### PR DESCRIPTION
This commit fixes a `405 Method Not Allowed` error that occurred when a user would navigate directly to the `/admin/user/<user_id>/delete` URL.

The `delete_user` route has been updated to accept both GET and POST requests. If a GET request is received, the user is redirected to the `manage_users` page with a flash message.