### PR TITLE
Fix: Correct url_for call in base.html

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -72,7 +72,7 @@
                         <!-- Farmers links as separate nav items -->
                         {% if current_user.farmer %}
                         <li class="nav-item">
-                            <a class="nav-link" href="{{ url_for('main.farmers') }}">Farmers Dashboard</a>
+                            <a class="nav-link" href="{{ url_for('main.farmer_dashboard') }}">Farmers Dashboard</a>
                         </li>
                         {% endif %}
                         <li class="nav-item">


### PR DESCRIPTION
This commit fixes a `werkzeug.routing.exceptions.BuildError` that occurred when rendering the `base.html` template. The error was caused by an incorrect endpoint name being used in the `url_for` function.

The `url_for('main.farmers')` call has been updated to `url_for('main.farmer_dashboard')` to reflect the new endpoint for the Farmer Dashboard.