### PR TITLE
Fix: Correct url_for call in contracts.html

### DIFF
--- a/app/templates/main/contracts.html
+++ b/app/templates/main/contracts.html
@@ -8,7 +8,7 @@
     <nav>
         <ul class="nav nav-pills mb-3">
             <li class="nav-item">
-                <a class="nav-link" href="{{ url_for('main.farmers') }}">Dashboard</a>
+                <a class="nav-link" href="{{ url_for('main.farmer_dashboard') }}">Dashboard</a>
             </li>
             <li class="nav-item">
                 <a class="nav-link active" href="{{ url_for('main.contracts') }}">Contracts</a>


### PR DESCRIPTION
This commit fixes a `werkzeug.routing.exceptions.BuildError` that occurred when rendering the `main/contracts.html` template. The error was caused by an incorrect endpoint name being used in the `url_for` function.

The `url_for('main.farmers')` call has been updated to `url_for('main.farmer_dashboard')` to reflect the new endpoint for the Farmer Dashboard.