### PR TITLE
Fix: Correct attribute name in banking dashboard template

### DIFF
--- a/app/templates/banking/dashboard.html
+++ b/app/templates/banking/dashboard.html
@@ -16,7 +16,7 @@
             </div>
             <div class="card-body">
                 <h4 class="card-title">Current Balance: {{ "%.2f"|format(detail.account.balance) }} {{ detail.account.currency }}</h4>
-                <p class="card-text">Owned by: {{ detail.account.owner_user.username }}</p>
+                <p class="card-text">Owned by: {{ detail.account.user.username }}</p>
                 <p class="card-text"><small class="text-muted">Last Updated: {{ detail.account.last_updated_on.strftime('%Y-%m-%d %H:%M:%S') if detail.account.last_updated_on else 'N/A' }}</small></p>
 
                 <h5 class="mt-4">Recent Transactions (Last 10)</h5>


### PR DESCRIPTION
This commit fixes a `jinja2.exceptions.UndefinedError` that occurred when rendering the `banking/dashboard.html` template. The error was caused by the template trying to access an `owner_user` attribute on the `Account` object, which does not exist.

The `banking/dashboard.html` template has been updated to use the correct `user` attribute instead of `owner_user`. This resolves the `UndefinedError` and allows the template to be rendered correctly.