### PR TITLE
Fix: Add base template to my_conducted_inspections.html

### DIFF
--- a/app/templates/dot/list_my_conducted_inspections.html
+++ b/app/templates/dot/list_my_conducted_inspections.html
@@ -1,3 +1,6 @@
+{% extends "base.html" %}
+
+{% block content %}
 <div class="container mt-4">
     <h1 class="mb-4">{{ title }}</h1>
 
@@ -64,3 +67,4 @@
         </ul>
     </nav>
 </div>
+{% endblock %}


### PR DESCRIPTION
This commit fixes an issue where the `/dot/inspections/my_conducted` page was not displaying the site's navigation bar.

The `list_my_conducted_inspections.html` template has been updated to extend the `base.html` template. This ensures that the page has the same layout and navigation bar as the other pages on the site.