### PR TITLE
Fix: Correct url_for call in admin/base.html

### DIFF
--- a/app/templates/admin/base.html
+++ b/app/templates/admin/base.html
@@ -69,7 +69,7 @@
 
                         <!-- Farmers links as separate nav items -->
                         <li class="nav-item">
-                            <a class="nav-link" href="{{ url_for('main.farmers') }}">Farmers Dashboard</a>
+                            <a class="nav-link" href="{{ url_for('main.farmer_dashboard') }}">Farmers Dashboard</a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link" href="{{ url_for('main.contracts') }}">Available Contracts</a>


### PR DESCRIPTION
This commit fixes a `werkzeug.routing.exceptions.BuildError` that occurred when rendering the `admin/base.html` template. The error was caused by an incorrect endpoint name being used in the `url_for` function.

The `url_for('main.farmers')` call has been updated to `url_for('main.farmer_dashboard')` to reflect the new endpoint for the Farmer Dashboard.