### PR TITLE
Fix: Add missing fields to ApplyPermitForm

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -31,6 +31,8 @@ class AccountForm(FlaskForm):
 
 class ApplyPermitForm(FlaskForm):
     vehicle_type = StringField('Vehicle Type/Description', validators=[DataRequired(), Length(min=5, max=150)])
+    license_plate = StringField('License Plate', validators=[DataRequired(), Length(min=2, max=20)])
+    operator_name = StringField('Operator Name', validators=[DataRequired(), Length(min=2, max=100)])
     route_details = TextAreaField('Proposed Route Details (From, Via, To)', validators=[DataRequired(), Length(min=10, max=1000)])
     travel_start_date = DateField('Travel Start Date', format='%Y-%m-%d', validators=[DataRequired()])
     travel_end_date = DateField('Travel End Date', format='%Y-%m-%d', validators=[DataRequired()])


### PR DESCRIPTION
This commit fixes a `jinja2.exceptions.UndefinedError` that occurred when rendering the `dot/apply_permit.html` template. The error was caused by the template trying to access a `license_plate` attribute on the `ApplyPermitForm` object, which did not exist.

The `ApplyPermitForm` in `app/forms.py` has been updated to include the `license_plate` and `operator_name` fields. This resolves the `UndefinedError` and allows the template to be rendered correctly.