### PR TITLE
Fix: Correct attribute name in apply_permit.html template

### DIFF
--- a/app/templates/dot/apply_permit.html
+++ b/app/templates/dot/apply_permit.html
@@ -33,8 +33,8 @@
         </div>
 
         <div class="mb-3">
-            {{ form.route.label(class="form-label") }}
-            {{ form.route(class="form-control", placeholder="Route details") }}
+            {{ form.route_details.label(class="form-label") }}
+            {{ form.route_details(class="form-control", placeholder="Route details") }}
         </div>
 
         <div class="mb-3">


### PR DESCRIPTION
This commit fixes a `jinja2.exceptions.UndefinedError` that occurred when rendering the `dot/apply_permit.html` template. The error was caused by the template trying to access a `route` attribute on the `ApplyPermitForm` object, which does not exist.

The `apply_permit.html` template has been updated to use the correct `route_details` attribute instead of `route`. This resolves the `UndefinedError` and allows the template to be rendered correctly.