### PR TITLE
Fix: Correct attribute names in apply_permit.html template

### DIFF
--- a/app/templates/dot/apply_permit.html
+++ b/app/templates/dot/apply_permit.html
@@ -38,13 +38,13 @@
         </div>
 
         <div class="mb-3">
-            {{ form.start_date.label(class="form-label") }}
-            {{ form.start_date(class="form-control") }}
+            {{ form.travel_start_date.label(class="form-label") }}
+            {{ form.travel_start_date(class="form-control") }}
         </div>
 
         <div class="mb-3">
-            {{ form.end_date.label(class="form-label") }}
-            {{ form.end_date(class="form-control") }}
+            {{ form.travel_end_date.label(class="form-label") }}
+            {{ form.travel_end_date(class="form-control") }}
         </div>
 
         <div class="mb-3">


### PR DESCRIPTION
This commit fixes a `jinja2.exceptions.UndefinedError` that occurred when rendering the `dot/apply_permit.html` template. The error was caused by the template trying to access `start_date` and `end_date` attributes on the `ApplyPermitForm` object, which do not exist.

The `apply_permit.html` template has been updated to use the correct `travel_start_date` and `travel_end_date` attributes instead. This resolves the `UndefinedError` and allows the template to be rendered correctly.