### PR TITLE
Fix: Correct attribute name in apply_permit.html template

### DIFF
--- a/app/templates/dot/apply_permit.html
+++ b/app/templates/dot/apply_permit.html
@@ -48,8 +48,8 @@
         </div>
 
         <div class="mb-3">
-            {{ form.notes.label(class="form-label") }}
-            {{ form.notes(class="form-control", rows=4, placeholder="Any additional information") }}
+            {{ form.user_notes.label(class="form-label") }}
+            {{ form.user_notes(class="form-control", rows=4, placeholder="Any additional information") }}
         </div>
 
         <button type="submit" class="btn btn-primary">{{ form.submit.label.text }}</button>


### PR DESCRIPTION
This commit fixes a `jinja2.exceptions.UndefinedError` that occurred when rendering the `dot/apply_permit.html` template. The error was caused by the template trying to access a `notes` attribute on the `ApplyPermitForm` object, which does not exist.

The `apply_permit.html` template has been updated to use the correct `user_notes` attribute instead of `notes`. This resolves the `UndefinedError` and allows the template to be rendered correctly.