### PR TITLE
Fix: Add base template to my_permit_applications.html

### DIFF
--- a/app/templates/dot/my_permit_applications.html
+++ b/app/templates/dot/my_permit_applications.html
@@ -1,40 +1,48 @@
-<table class="table table-striped table-hover table-sm">
-    <thead class="table-dark">
-        <tr>
-            <th scope="col">App ID</th>
-            <th scope="col">Vehicle Type</th>
-            <th scope="col">Travel Dates</th>
-            <th scope="col">Application Date</th>
-            <th scope="col">Status</th>
-            <th scope="col">Fee</th>
-            <th scope="col">Actions</th>
-        </tr>
-    </thead>
-    <tbody>
-        {% for app in applications_pagination.items %}
-        <tr>
-            <td>{{ app.id }}</td>
-            <td>{{ app.vehicle_type|truncate(40, True) }}</td>
-            <td>{{ app.travel_start_date.strftime('%Y-%m-%d') if app.travel_start_date else 'N/A' }} to {{ app.travel_end_date.strftime('%Y-%m-%d') if app.travel_end_date else 'N/A' }}</td>
-            <td>{{ app.application_date.strftime('%Y-%m-%d %H:%M') if app.application_date else 'N/A' }}</td>
-            <td>
-                <span class="badge bg-{{
-                    'primary' if app.status == PermitApplicationStatus.PENDING_REVIEW
-                    else 'info' if app.status == PermitApplicationStatus.REQUIRES_MODIFICATION
-                    else 'warning' if app.status == PermitApplicationStatus.APPROVED_PENDING_PAYMENT
-                    else 'secondary' if app.status == PermitApplicationStatus.PAID_AWAITING_ISSUANCE
-                    else 'success' if app.status == PermitApplicationStatus.ISSUED
-                    else 'danger' if app.status == PermitApplicationStatus.REJECTED or app.status == PermitApplicationStatus.CANCELLED_BY_ADMIN
-                    else 'dark' if app.status == PermitApplicationStatus.CANCELLED_BY_USER
-                    else 'light' }}">
-                    {{ app.status.value }}
-                </span>
-            </td>
-            <td>{{ "%.2f"|format(app.permit_fee) if app.permit_fee else 'N/A' }}</td>
-            <td>
-                <a href="{{ url_for('dot.view_permit_application_detail', application_id=app.id) }}" class="btn btn-sm btn-info">View Details</a>
-            </td>
-        </tr>
-        {% endfor %}
-    </tbody>
-</table>
+{% extends "base.html" %}
+
+{% block content %}
+<div class="container mt-4">
+    <h1 class="mb-4">{{ title }}</h1>
+    <a href="{{ url_for('dot.apply_for_permit') }}" class="btn btn-primary mb-3">Apply for New Permit</a>
+    <table class="table table-striped table-hover table-sm">
+        <thead class="table-dark">
+            <tr>
+                <th scope="col">App ID</th>
+                <th scope="col">Vehicle Type</th>
+                <th scope="col">Travel Dates</th>
+                <th scope="col">Application Date</th>
+                <th scope="col">Status</th>
+                <th scope="col">Fee</th>
+                <th scope="col">Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for app in applications_pagination.items %}
+            <tr>
+                <td>{{ app.id }}</td>
+                <td>{{ app.vehicle_type|truncate(40, True) }}</td>
+                <td>{{ app.travel_start_date.strftime('%Y-%m-%d') if app.travel_start_date else 'N/A' }} to {{ app.travel_end_date.strftime('%Y-%m-%d') if app.travel_end_date else 'N/A' }}</td>
+                <td>{{ app.application_date.strftime('%Y-%m-%d %H:%M') if app.application_date else 'N/A' }}</td>
+                <td>
+                    <span class="badge bg-{{
+                        'primary' if app.status == PermitApplicationStatus.PENDING_REVIEW
+                        else 'info' if app.status == PermitApplicationStatus.REQUIRES_MODIFICATION
+                        else 'warning' if app.status == PermitApplicationStatus.APPROVED_PENDING_PAYMENT
+                        else 'secondary' if app.status == PermitApplicationStatus.PAID_AWAITING_ISSUANCE
+                        else 'success' if app.status == PermitApplicationStatus.ISSUED
+                        else 'danger' if app.status == PermitApplicationStatus.REJECTED or app.status == PermitApplicationStatus.CANCELLED_BY_ADMIN
+                        else 'dark' if app.status == PermitApplicationStatus.CANCELLED_BY_USER
+                        else 'light' }}">
+                        {{ app.status.value }}
+                    </span>
+                </td>
+                <td>{{ "%.2f"|format(app.permit_fee) if app.permit_fee else 'N/A' }}</td>
+                <td>
+                    <a href="{{ url_for('dot.view_permit_application_detail', application_id=app.id) }}" class="btn btn-sm btn-info">View Details</a>
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+{% endblock %}


### PR DESCRIPTION
This commit fixes an issue where the `/dot/permits/my_applications` page was not displaying the site's navigation bar.

The `my_permit_applications.html` template has been updated to extend the `base.html` template. This ensures that the page has the same layout and navigation bar as the other pages on the site.