### PR TITLE
Fix: Correct attribute name in manage_tax_brackets route

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -138,7 +138,7 @@ def manage_permits():
 @login_required
 @admin_required
 def manage_tax_brackets():
-    tax_brackets = TaxBracket.query.order_by(TaxBracket.income_min.asc()).all()
+    tax_brackets = TaxBracket.query.order_by(TaxBracket.min_balance.asc()).all()
     return render_template('admin/manage_tax_brackets.html', tax_brackets=tax_brackets)
 
 @admin_bp.route('/manage/transactions')


### PR DESCRIPTION
This commit fixes an `AttributeError` that occurred when rendering the `admin/manage_tax_brackets.html` template. The error was caused by the route trying to order the `TaxBracket` query by the `income_min` attribute, which does not exist.

The `manage_tax_brackets` route in `app/routes/admin.py` has been updated to use the correct `min_balance` attribute instead of `income_min`. This resolves the `AttributeError` and allows the template to be rendered correctly.