### PR TITLE
feat: Add fines management section

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -206,6 +206,13 @@ class EditUserRoleForm(FlaskForm):
     submit = SubmitField('Update Role')
 
 
+class FineForm(FlaskForm):
+    name = StringField('Fine Name', validators=[DataRequired(), Length(max=100)])
+    description = TextAreaField('Description', validators=[Optional(), Length(max=1000)])
+    amount = DecimalField('Amount', places=2, validators=[DataRequired()])
+    submit = SubmitField('Save Fine')
+
+
 class FarmerForm(FlaskForm):
     submit = SubmitField('Register as Farmer')
 

--- a/app/models.py
+++ b/app/models.py
@@ -504,6 +504,16 @@ class CompanyContract(db.Model):
     def __repr__(self):
         return f'<CompanyContract {self.id}: {self.title}>'
 
+class Fine(db.Model):
+    __tablename__ = 'fines'
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(100), nullable=False, unique=True)
+    description = db.Column(db.Text, nullable=True)
+    amount = db.Column(db.Numeric(10, 2), nullable=False)
+
+    def __repr__(self):
+        return f'<Fine {self.name}: {self.amount}>'
+
 class CompanyInsuranceClaim(db.Model):
     __tablename__ = 'company_insurance_claims'
     id = db.Column(db.Integer, primary_key=True)

--- a/app/templates/admin/base.html
+++ b/app/templates/admin/base.html
@@ -49,6 +49,7 @@
                                     <li><a class="dropdown-item" href="{{ url_for('admin.manage_users') }}">Manage Users</a></li>
                                     <li><a class="dropdown-item" href="{{ url_for('admin.manage_accounts') }}">Manage Accounts</a></li>
                                     <li><a class="dropdown-item" href="{{ url_for('admin.manage_tickets') }}">Manage Tickets</a></li>
+                                    <li><a class="dropdown-item" href="{{ url_for('admin.manage_fines') }}">Manage Fines</a></li>
                                     <li><a class="dropdown-item" href="{{ url_for('admin.manage_permits') }}">Manage Permits</a></li>
                                     <li><a class="dropdown-item" href="{{ url_for('admin.manage_inspections') }}">Manage Inspections</a></li>
                                     <li><a class="dropdown-item" href="{{ url_for('admin.manage_tax_brackets') }}">Manage Tax Brackets</a></li>

--- a/app/templates/admin/edit_fine.html
+++ b/app/templates/admin/edit_fine.html
@@ -1,0 +1,19 @@
+{% extends "admin/base.html" %}
+{% import "bootstrap_wtf.html" as wtf %}
+
+{% block content %}
+<div class="container">
+    <h1 class="my-4">{{ title }}</h1>
+    <div class="row">
+        <div class="col-md-8">
+            <form method="POST" action="">
+                {{ form.hidden_tag() }}
+                {{ wtf.render_field(form.name) }}
+                {{ wtf.render_field(form.description, rows=5) }}
+                {{ wtf.render_field(form.amount) }}
+                {{ wtf.render_field(form.submit, class="btn btn-primary") }}
+            </form>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/app/templates/admin/manage_fines.html
+++ b/app/templates/admin/manage_fines.html
@@ -1,0 +1,55 @@
+{% extends "admin/base.html" %}
+{% block content %}
+<div class="container">
+    <h1 class="my-4">Manage Fines</h1>
+    <a href="{{ url_for('admin.add_fine') }}" class="btn btn-primary mb-3">Add New Fine</a>
+    <div class="table-responsive">
+        <table class="table table-striped table-hover">
+            <thead class="thead-dark">
+                <tr>
+                    <th>ID</th>
+                    <th>Name</th>
+                    <th>Description</th>
+                    <th>Amount</th>
+                    <th>Actions</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for fine in fines.items %}
+                <tr>
+                    <td>{{ fine.id }}</td>
+                    <td>{{ fine.name }}</td>
+                    <td>{{ fine.description }}</td>
+                    <td>${{ "%.2f"|format(fine.amount) }}</td>
+                    <td>
+                        <a href="{{ url_for('admin.edit_fine', fine_id=fine.id) }}" class="btn btn-sm btn-outline-primary">Edit</a>
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+
+    <nav aria-label="Page navigation">
+        <ul class="pagination justify-content-center">
+            {% if fines.has_prev %}
+            <li class="page-item"><a class="page-link" href="{{ url_for('admin.manage_fines', page=fines.prev_num) }}">Previous</a></li>
+            {% endif %}
+
+            {% for page_num in fines.iter_pages() %}
+                {% if page_num %}
+                    <li class="page-item {% if fines.page == page_num %}active{% endif %}">
+                        <a class="page-link" href="{{ url_for('admin.manage_fines', page=page_num) }}">{{ page_num }}</a>
+                    </li>
+                {% else %}
+                    <li class="page-item disabled"><span class="page-link">...</span></li>
+                {% endif %}
+            {% endfor %}
+
+            {% if fines.has_next %}
+            <li class="page-item"><a class="page-link" href="{{ url_for('admin.manage_fines', page=fines.next_num) }}">Next</a></li>
+            {% endif %}
+        </ul>
+    </nav>
+</div>
+{% endblock %}

--- a/run.py
+++ b/run.py
@@ -17,7 +17,7 @@ from app.models import (
     AutomatedTaxDeductionLog, Ticket, TicketStatus,
     PermitApplication, PermitApplicationStatus,
     MarketplaceListing, MarketplaceListingStatus,
-    Inspection
+    Inspection, Fine
 )
 
 # Flask shell context
@@ -38,8 +38,40 @@ def make_shell_context():
         'PermitApplicationStatus': PermitApplicationStatus,
         'MarketplaceListing': MarketplaceListing,
         'MarketplaceListingStatus': MarketplaceListingStatus,
-        'Inspection': Inspection
+        'Inspection': Inspection,
+        'Fine': Fine
     }
+
+def seed_fines():
+    from app.models import Fine
+    from decimal import Decimal
+
+    fines_to_seed = [
+        {'name': 'Speeding (1-15 mph over)', 'description': 'Exceeding the speed limit by 1-15 mph.', 'amount': Decimal('75.00')},
+        {'name': 'Speeding (16-30 mph over)', 'description': 'Exceeding the speed limit by 16-30 mph.', 'amount': Decimal('150.00')},
+        {'name': 'Speeding (31+ mph over)', 'description': 'Exceeding the speed limit by 31 or more mph.', 'amount': Decimal('300.00')},
+        {'name': 'Illegal Parking', 'description': 'Parking in a restricted area.', 'amount': Decimal('50.00')},
+        {'name': 'Running a Red Light', 'description': 'Failing to stop at a red light.', 'amount': Decimal('100.00')},
+        {'name': 'Reckless Driving', 'description': 'Driving with willful or wanton disregard for the safety of persons or property.', 'amount': Decimal('500.00')},
+        {'name': 'Expired Vehicle Registration', 'description': 'Operating a vehicle with an expired registration.', 'amount': Decimal('60.00')},
+        {'name': 'No Proof of Insurance', 'description': 'Operating a vehicle without proof of insurance.', 'amount': Decimal('200.00')},
+    ]
+
+    existing_fines = {fine.name for fine in Fine.query.all()}
+    new_fines_added = 0
+
+    for fine_data in fines_to_seed:
+        if fine_data['name'] not in existing_fines:
+            new_fine = Fine(
+                name=fine_data['name'],
+                description=fine_data['description'],
+                amount=fine_data['amount']
+            )
+            db.session.add(new_fine)
+            new_fines_added += 1
+
+    if new_fines_added > 0:
+        db.session.commit()
 
 def seed_insurance_rates():
     from app.models import InsuranceRate, InsuranceRateType
@@ -79,6 +111,10 @@ if __name__ == '__main__':
         logger.info("Seeding insurance rates...")
         seed_insurance_rates()
         logger.info("Insurance rates seeded.")
+
+        logger.info("Seeding fines...")
+        seed_fines()
+        logger.info("Fines seeded.")
 
         # Create default admin if it doesn't exist
         admin_username = 'admin'


### PR DESCRIPTION
This commit introduces a new section for managing fines, which is accessible to administrators.

The new functionality includes:
- A new `Fine` model to store fine details.
- A form to add and edit fines.
- Routes and templates for listing, adding, and editing fines.
- A link in the admin navigation to the new "Manage Fines" page.
- Seeding of the database with a list of common vehicle-related fines.