### PR TITLE
feat: Add fines page and nav link, and adjust admin dashboard

### DIFF
--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -9,7 +9,7 @@ from app.models import (
     User, UserRole, RulesContent, Farmer, Parcel, UserVehicle, CompanyVehicle,
     Account, InsuranceClaim, Contract, ContractStatus, Company, CompanyContract, CompanyInsuranceClaim,
     MarketplaceListing, MarketplaceListingStatus, Ticket, PermitApplication,
-    Transaction, TransactionType, InsuranceRate
+    Transaction, TransactionType, InsuranceRate, Fine
 )
 from app.forms import (
     ParcelForm, InsuranceClaimForm, ContractForm, CompanyNameForm, CompanyVehicleForm, CompanyContractForm, CompanyInsuranceClaimForm
@@ -81,6 +81,12 @@ def view_rules():
     return render_template('main/rules.html', title='Rules',
                            rules_content_html=rules_content_html,
                            current_user=current_user, UserRole=UserRole)
+
+
+@main_bp.route('/fines', endpoint='fines')
+def fines():
+    fines = Fine.query.order_by(Fine.name.asc()).all()
+    return render_template('main/fines.html', title='Fines', fines=fines)
 
 
 # ------------------------ ADMIN ------------------------

--- a/app/templates/admin/dashboard.html
+++ b/app/templates/admin/dashboard.html
@@ -15,6 +15,7 @@
     </div>
   </div>
 
+  {% if current_user.role == UserRole.ADMIN or current_user.role == UserRole.OFFICER %}
   <div class="col-md-3">
     <div class="card text-bg-warning">
       <div class="card-body">
@@ -32,6 +33,7 @@
       </div>
     </div>
   </div>
+  {% endif %}
 
   <div class="col-md-3">
     <div class="card text-bg-success">

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -92,6 +92,10 @@
                         </li>
 
                         <li class="nav-item">
+                            <a class="nav-link" href="{{ url_for('main.fines') }}">Fines</a>
+                        </li>
+
+                        <li class="nav-item">
                             <a class="nav-link" href="{{ url_for('messaging.list_my_conversations') }}">
                                 Messages
                                 {% if unread_message_count and unread_message_count > 0 %}

--- a/app/templates/main/fines.html
+++ b/app/templates/main/fines.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="container">
+    <h1 class="my-4">Fines</h1>
+    <div class="table-responsive">
+        <table class="table table-striped table-hover">
+            <thead class="thead-dark">
+                <tr>
+                    <th>Name</th>
+                    <th>Description</th>
+                    <th>Amount</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for fine in fines %}
+                <tr>
+                    <td>{{ fine.name }}</td>
+                    <td>{{ fine.description }}</td>
+                    <td>${{ "%.2f"|format(fine.amount) }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
This commit introduces the following changes:
- A new "Fines" page that displays a list of all fines.
- A "Fines" link in the main navigation bar.
- The admin dashboard now conditionally displays the number of open tickets and pending permits, only showing them to users with the "officer" or "admin" role.