### PR TITLE
fix: Pass TicketStatus to resolve_ticket template

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -246,7 +246,7 @@ def resolve_ticket(ticket_id):
         flash('Ticket has been successfully resolved.', 'success')
         return redirect(url_for('admin.manage_tickets'))
 
-    return render_template('admin/resolve_ticket.html', title='Resolve Ticket', form=form, ticket=ticket)
+    return render_template('admin/resolve_ticket.html', title='Resolve Ticket', form=form, ticket=ticket, TicketStatus=TicketStatus)
 
 
 @admin_bp.route('/ticket/<int:ticket_id>/cancel', methods=['POST'])


### PR DESCRIPTION
This change fixes a `jinja2.exceptions.UndefinedError` that occurred on the 'Resolve Ticket' page. The template was trying to access the `TicketStatus` enum without it being in the context.

This commit updates the `resolve_ticket` view function to pass the `TicketStatus` enum to the `render_template` call, making it available to the template and resolving the error.