### PR TITLE
fix: Correct broken admin link on issue ticket page

### DIFF
--- a/app/templates/dot/issue_ticket.html
+++ b/app/templates/dot/issue_ticket.html
@@ -35,7 +35,7 @@
             <div class="d-flex gap-2 mt-3">
                 <a href="{{ url_for('dot.list_issued_tickets') }}" class="btn btn-secondary flex-grow-1">Back to My Issued Tickets</a>
                 {% if current_user.role == UserRole.ADMIN %}
-                <a href="{{ url_for('admin.tickets') }}" class="btn btn-info flex-grow-1">Admin Ticket Management</a>
+                <a href="{{ url_for('admin.manage_tickets') }}" class="btn btn-info flex-grow-1">Admin Ticket Management</a>
                 {% endif %}
             </div>
         </div>


### PR DESCRIPTION
This commit fixes a `BuildError` on the 'Issue Ticket' page (`/dot/issue_ticket`). The link to the admin ticket management page was pointing to a non-existent endpoint, `admin.tickets`.

This has been corrected to point to the valid `admin.manage_tickets` endpoint.