### PR TITLE
fix: Prevent crash on manage contracts page

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -105,7 +105,7 @@ def edit_account(account_id):
 @login_required
 @admin_required
 def manage_contracts():
-    contracts = Contract.query.order_by(Contract.created_at.desc()).all()
+    contracts = Contract.query.order_by(Contract.id.desc()).all()
     return render_template('admin/manage_contracts.html', contracts=contracts)
 
 


### PR DESCRIPTION
This commit fixes an `AttributeError` that was crashing the 'Manage Contracts' page in the admin panel.

The page was trying to sort contracts by a `created_at` attribute that does not exist on the `Contract` model. The query has been changed to sort by `id` in descending order instead, which achieves the same goal of showing the newest contracts first and prevents the application from crashing.