### PR TITLE
fix: Add pagination to manage contracts page

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -105,7 +105,11 @@ def edit_account(account_id):
 @login_required
 @admin_required
 def manage_contracts():
-    contracts = Contract.query.order_by(Contract.id.desc()).all()
+    page = request.args.get('page', 1, type=int)
+    per_page = 20 # A common value in this app
+    contracts = Contract.query.order_by(Contract.id.desc()).paginate(
+        page=page, per_page=per_page, error_out=False
+    )
     return render_template('admin/manage_contracts.html', contracts=contracts)
 
 


### PR DESCRIPTION
This commit fixes a `jinja2.exceptions.UndefinedError` that was crashing the 'Manage Contracts' page. The template was attempting to render pagination controls but was receiving a simple list from the backend instead of a pagination object.

The `manage_contracts` function has been updated to use `paginate()` instead of `all()`, providing the template with the necessary object to render the page links correctly.