### PR TITLE
This commit fixes a "CSRF token missing" error that occurred when try…

### DIFF
--- a/app/templates/messaging/conversation_thread.html
+++ b/app/templates/messaging/conversation_thread.html
@@ -44,6 +44,7 @@
     </form>
 
     <form method="POST" action="{{ url_for('messaging.close_conversation_route', conversation_id=conversation.id) }}" class="mt-3" onsubmit="return confirm('Are you sure you want to close this conversation? You will not be able to send more messages.');">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
         <input type="submit" value="Close Conversation" class="btn btn-sm btn-outline-danger">
     </form>
 


### PR DESCRIPTION
…ing to close a conversation.

The form for closing a conversation was missing a CSRF token, which caused the POST request to fail. This commit adds a hidden input field with the CSRF token to the form.