### PR TITLE
This commit fixes a NameError for 'render_template' in `app/__init__.…

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,6 +1,6 @@
 import os
 import re
-from flask import Flask
+from flask import Flask, render_template
 from flask_sqlalchemy import SQLAlchemy
 from flask_login import LoginManager
 from flask_apscheduler import APScheduler


### PR DESCRIPTION
…py`.

The `render_template` function was being used in a 404 error handler but was not imported from Flask. This commit adds the necessary import to resolve the error.