### PR TITLE
Fix TypeError in Jinja2 templates for form rendering

### DIFF
--- a/app/templates/main/create_contract.html
+++ b/app/templates/main/create_contract.html
@@ -6,7 +6,7 @@
     <h1>Create Contract</h1>
     <div class="row">
         <div class="col-md-6">
-            {{ wtf.quick_form(form, action_url=url_for('main.create_contract'), method="POST") }}
+            {{ wtf.quick_form(form, action=url_for('main.create_contract'), method="POST") }}
         </div>
     </div>
 </div>

--- a/app/templates/main/farmer_dashboard.html
+++ b/app/templates/main/farmer_dashboard.html
@@ -100,7 +100,7 @@
                 {{ parcel_form.hidden_tag() }}
                 {{ wtf.render_field(parcel_form.location) }}
                 {{ wtf.render_field(parcel_form.size) }}
-                {{ wtf.render_field(parcel_form.submit, button_map={'submit': 'btn-primary'}) }}
+                {{ wtf.render_field(parcel_form.submit) }}
             </form>
         </div>
     </div>
@@ -207,7 +207,7 @@
                     </div>
                 </div>
                 {{ wtf.render_field(insurance_form.description) }}
-                {{ wtf.render_field(insurance_form.submit, button_map={'submit': 'btn-warning'}) }}
+                {{ wtf.render_field(insurance_form.submit, field_class='btn-warning') }}
             </form>
         </div>
     </div>


### PR DESCRIPTION
This commit addresses two separate `TypeError` issues found in the Jinja2 templates.

The first issue, which was the original problem, was a `TypeError` in `app/templates/main/farmer_dashboard.html` where the `render_field` macro was called with an unsupported `button_map` keyword argument. This was fixed by removing the `button_map` argument and using the `field_class` argument instead where a non-default button style was required.

The second issue was discovered while running the tests. A similar `TypeError` occurred in `app/templates/main/create_contract.html` where the `quick_form` macro was called with an `action_url` keyword argument instead of the supported `action` argument. This was also fixed by renaming the argument.