### PR TITLE
Fix NameError in admin routes

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -8,7 +8,7 @@ from app.models import (
     User, Account, Ticket, PermitApplication, Inspection, TaxBracket, Transaction,
     TransactionType, VehicleRegion, RulesContent, UserRole, InsuranceClaim,
     InsuranceClaimStatus, PermitApplicationStatus, TicketStatus, Contract,
-    Conversation, Message, Fine
+    Conversation, Message, Fine, Farmer
 )
 from app.forms import (
     EditRulesForm, EditUserForm, AccountForm, EditAccountForm, EditTicketForm, EditPermitForm,


### PR DESCRIPTION
This commit fixes a `NameError: name 'Farmer' is not defined` in `app/routes/admin.py`.

The error was caused by using the `Farmer` model in a `joinedload` call within the `manage_insurance_claims` route without importing it first. This commit adds the `Farmer` model to the list of imports from `app.models`, resolving the error.