### PR TITLE
Fix admin templates not rendering content

### DIFF
--- a/app/templates/admin/edit_insurance_claim.html
+++ b/app/templates/admin/edit_insurance_claim.html
@@ -1,6 +1,6 @@
 {% extends "admin/base.html" %}
 
-{% block admin_content %}
+{% block content %}
 <div class="container-fluid">
     <h1 class="mt-4">Edit Insurance Claim #{{ claim.id }}</h1>
     <div class="card mb-4">

--- a/app/templates/admin/manage_insurance_claims.html
+++ b/app/templates/admin/manage_insurance_claims.html
@@ -1,6 +1,6 @@
 {% extends "admin/base.html" %}
 
-{% block admin_content %}
+{% block content %}
 <div class="container-fluid mt-4">
     <h1 class="mb-4">Manage Insurance Claims</h1>
 

--- a/app/templates/admin/validate_parcels.html
+++ b/app/templates/admin/validate_parcels.html
@@ -1,6 +1,6 @@
 {% extends "admin/base.html" %}
 
-{% block admin_content %}
+{% block content %}
     <h2>Validate Parcels</h2>
 
     {% if parcels %}


### PR DESCRIPTION
This commit fixes a bug where several admin pages were not rendering any content below the navigation bar.

The issue was caused by the child templates (e.g., `manage_insurance_claims.html`) using `{% block admin_content %}` while the parent template (`admin/base.html`) was expecting `{% block content %}`.

This commit renames the block in the following files to `content` to match the parent template, allowing the page content to be rendered correctly:
- `app/templates/admin/edit_insurance_claim.html`
- `app/templates/admin/manage_insurance_claims.html`
- `app/templates/admin/validate_parcels.html`