### PR TITLE
Fix insurance claims not appearing on admin page

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -201,9 +201,7 @@ def manage_inspections():
 def manage_insurance_claims():
     page = request.args.get('page', 1, type=int)
     per_page = 20
-    claims = InsuranceClaim.query.options(
-        db.joinedload(InsuranceClaim.farmer).joinedload(Farmer.user)
-    ).order_by(InsuranceClaim.claim_date.desc()).paginate(page=page, per_page=per_page)
+    claims = InsuranceClaim.query.order_by(InsuranceClaim.claim_date.desc()).paginate(page=page, per_page=per_page)
     return render_template('admin/manage_insurance_claims.html', claims=claims, title="Manage Insurance Claims")
 
 


### PR DESCRIPTION
This commit fixes a bug where the `/admin/manage/insurance-claims` page was not displaying any claims, even if they existed in the database.

The issue was caused by the database query using `joinedload`, which performs an `INNER JOIN`. If an insurance claim was associated with a farmer or user that had been deleted, the claim would be excluded from the results.

This commit simplifies the query by removing the `joinedload` options. This ensures that all insurance claims are fetched from the database and displayed correctly, at the cost of a minor performance decrease (more SQL queries). The query can be optimized later with a proper `OUTER JOIN` if needed.